### PR TITLE
Switch docker registry from registry.tensorstack.cn to dockerhub

### DIFF
--- a/aimd/job/job.yaml
+++ b/aimd/job/job.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/aimd/job/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -28,7 +28,7 @@ spec:
                 - "aimd/job/log"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 8
@@ -57,7 +57,7 @@ spec:
                 - aimd/job/torch_mnist_trainingjob_aimd.py
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 8

--- a/aimd/single-worker/job.yaml
+++ b/aimd/single-worker/job.yaml
@@ -22,7 +22,7 @@ spec:
                 - ""
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 8

--- a/autotune/hpo-keras/autotune.yaml
+++ b/autotune/hpo-keras/autotune.yaml
@@ -32,7 +32,7 @@ spec:
                   - autotune/hpo-keras/keras_mnist_autotune.py
                   - "--no_cuda"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+                image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
                 resources:
                   requests:
                     cpu: 2

--- a/autotune/hpo-keras/autotune_gpu.yaml
+++ b/autotune/hpo-keras/autotune_gpu.yaml
@@ -31,7 +31,7 @@ spec:
                   - python
                   - autotune/hpo-keras/keras_mnist_autotune.py
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+                image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
                 resources:
                   requests:
                     cpu: 1

--- a/autotune/hpo-keras/autotune_gpu_t9ksched.yaml
+++ b/autotune/hpo-keras/autotune_gpu_t9ksched.yaml
@@ -35,7 +35,7 @@ spec:
                   - python
                   - autotune/hpo-keras/keras_mnist_autotune.py
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+                image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
                 resources:
                   requests:
                     cpu: 1

--- a/autotune/hpo-torch/autotune.yaml
+++ b/autotune/hpo-torch/autotune.yaml
@@ -31,7 +31,7 @@ spec:
                   - "gloo"
                   - "--no_cuda"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+                image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
                 resources:
                   requests:
                     cpu: 8
@@ -61,7 +61,7 @@ spec:
                   - "gloo"
                   - "--no_cuda"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+                image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
                 resources:
                   requests:
                     cpu: 8

--- a/autotune/hpo-torch/autotune_gpu.yaml
+++ b/autotune/hpo-torch/autotune_gpu.yaml
@@ -30,7 +30,7 @@ spec:
                   - "--backend"
                   - "nccl"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+                image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
                 resources:
                   requests:
                     cpu: 1
@@ -61,7 +61,7 @@ spec:
                   - "--backend"
                   - "nccl"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+                image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
                 resources:
                   requests:
                     cpu: 1

--- a/autotune/hpo-torch/autotune_gpu_t9ksched.yaml
+++ b/autotune/hpo-torch/autotune_gpu_t9ksched.yaml
@@ -34,7 +34,7 @@ spec:
                   - "--backend"
                   - "nccl"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+                image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
                 resources:
                   requests:
                     cpu: 1
@@ -65,7 +65,7 @@ spec:
                   - "--backend"
                   - "nccl"
                 workingDir: /t9k/mnt/tutorial-examples
-                image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+                image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
                 resources:
                   requests:
                     cpu: 1

--- a/codepack/notebook.yaml
+++ b/codepack/notebook.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         - name: notebook
-          image: registry.tensorstack.cn/t9k/tensorflow-2.8.0-notebook-cpu:1.50.0
+          image: t9kpublic/tensorflow-2.8.0-notebook-cpu:1.64.1
           resources:
             limits:
               cpu: 2

--- a/codepack/trainingjob.yaml
+++ b/codepack/trainingjob.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/codepack-example/codepack/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: worker
       replicas: 4
@@ -25,7 +25,7 @@ spec:
                 - "--save_path"
                 - "saved_model"
               workingDir: /t9k/mnt/codepack
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:

--- a/deployment/pvc/mlservice-keras/mlservice.yaml
+++ b/deployment/pvc/mlservice-keras/mlservice.yaml
@@ -10,7 +10,7 @@ spec:
         maxReplicas: 1
         minReplicas: 1
         tensorflow:
-          image: registry.tensorstack.cn/t9kmirror/tensorflow-serving:2.6.0
+          image: t9kpublicmirror/tensorflow-serving:2.6.0
           modelUri: pvc://tutorial/tutorial-examples/deployment/pvc/mlservice-keras/saved_model/
           resources:
             limits:

--- a/deployment/pvc/mlservice-torch/mlservice.yaml
+++ b/deployment/pvc/mlservice-torch/mlservice.yaml
@@ -10,7 +10,7 @@ spec:
         maxReplicas: 1
         minReplicas: 1
         pytorch:
-          image: registry.tensorstack.cn/t9kmirror/pytorch-serve:0.4.2-cpu
+          image: t9kpublicmirror/pytorch-serve:0.4.2-cpu
           modelUri: pvc://tutorial/tutorial-examples/deployment/pvc/mlservice-torch/
           resources:
             limits:

--- a/deployment/s3/mlservice-keras/mlservice.yaml
+++ b/deployment/s3/mlservice-keras/mlservice.yaml
@@ -10,7 +10,7 @@ spec:
         maxReplicas: 1
         minReplicas: 1
         tensorflow:
-          image: registry.tensorstack.cn/t9kmirror/tensorflow-serving:2.6.0
+          image: t9kpublicmirror/tensorflow-serving:2.6.0
           modelUri: s3://tutorial/keras-mnist/
           resources:
             limits:

--- a/deployment/s3/mlservice-torch/mlservice.yaml
+++ b/deployment/s3/mlservice-torch/mlservice.yaml
@@ -10,7 +10,7 @@ spec:
         maxReplicas: 1
         minReplicas: 1
         pytorch:
-          image: registry.tensorstack.cn/t9kmirror/pytorch-serve:0.4.2-cpu
+          image: t9kpublicmirror/pytorch-serve:0.4.2-cpu
           modelUri: s3://tutorial/torch-mnist/
           resources:
             limits:

--- a/job/genericjob/keras-multiworker/job.yaml
+++ b/job/genericjob/keras-multiworker/job.yaml
@@ -35,7 +35,7 @@ spec:
               env:
                 - name: TF_CONFIG
                   value: '{"cluster":{"worker":["$(service.worker[0].host):$(service.port[http])","$(service.worker[1].host):$(service.port[http])","$(service.worker[2].host):$(service.port[http])","$(service.worker[3].host):$(service.port[http])"]},"task":{"type":"$(type)","index":$(rank)}}'
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               resources:
                 requests:
                   cpu: 2

--- a/job/genericjob/keras-multiworker/job_gpu.yaml
+++ b/job/genericjob/keras-multiworker/job_gpu.yaml
@@ -34,7 +34,7 @@ spec:
               env:
                 - name: TF_CONFIG
                   value: '{"cluster":{"worker":["$(service.worker[0].host):$(service.port[http])","$(service.worker[1].host):$(service.port[http])","$(service.worker[2].host):$(service.port[http])","$(service.worker[3].host):$(service.port[http])"]},"task":{"type":"$(type)","index":$(rank)}}'
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
               resources:
                 requests:
                   cpu: 1

--- a/job/genericjob/keras-multiworker/job_gpu_t9ksched.yaml
+++ b/job/genericjob/keras-multiworker/job_gpu_t9ksched.yaml
@@ -37,7 +37,7 @@ spec:
               env:
                 - name: TF_CONFIG
                   value: '{"cluster":{"worker":["$(service.worker[0].host):$(service.port[http])","$(service.worker[1].host):$(service.port[http])","$(service.worker[2].host):$(service.port[http])","$(service.worker[3].host):$(service.port[http])"]},"task":{"type":"$(type)","index":$(rank)}}'
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
               resources:
                 requests:
                   cpu: 1

--- a/job/mpijob/horovod-keras/job.yaml
+++ b/job/mpijob/horovod-keras/job.yaml
@@ -27,7 +27,7 @@ spec:
       spec:
         containers:
           - name: mpi-worker
-            image: registry.tensorstack.cn/t9k/horovod:sdk-0.5.2
+            image: t9kpublic/horovod:sdk-0.5.2
             workingDir: /t9k/mnt/tutorial-examples
             resources:
               requests:

--- a/job/mpijob/horovod-keras/job_gpu.yaml
+++ b/job/mpijob/horovod-keras/job_gpu.yaml
@@ -26,7 +26,7 @@ spec:
       spec:
         containers:
           - name: mpi-worker
-            image: registry.tensorstack.cn/t9k/horovod:sdk-0.5.2
+            image: t9kpublic/horovod:sdk-0.5.2
             workingDir: /t9k/mnt/tutorial-examples
             resources:
               requests:

--- a/job/mpijob/horovod-keras/job_gpu_t9ksched.yaml
+++ b/job/mpijob/horovod-keras/job_gpu_t9ksched.yaml
@@ -30,7 +30,7 @@ spec:
       spec:
         containers:
           - name: mpi-worker
-            image: registry.tensorstack.cn/t9k/horovod:sdk-0.5.2
+            image: t9kpublic/horovod:sdk-0.5.2
             workingDir: /t9k/mnt/tutorial-examples
             resources:
               requests:

--- a/job/mpijob/horovod-torch/job.yaml
+++ b/job/mpijob/horovod-torch/job.yaml
@@ -27,7 +27,7 @@ spec:
       spec:
         containers:
           - name: mpi-worker
-            image: registry.tensorstack.cn/t9k/horovod:sdk-0.5.2
+            image: t9kpublic/horovod:sdk-0.5.2
             workingDir: /t9k/mnt/tutorial-examples
             resources:
               requests:

--- a/job/mpijob/horovod-torch/job_gpu.yaml
+++ b/job/mpijob/horovod-torch/job_gpu.yaml
@@ -26,7 +26,7 @@ spec:
       spec:
         containers:
           - name: mpi-worker
-            image: registry.tensorstack.cn/t9k/horovod:sdk-0.5.2
+            image: t9kpublic/horovod:sdk-0.5.2
             workingDir: /t9k/mnt/tutorial-examples
             resources:
               requests:

--- a/job/mpijob/horovod-torch/job_gpu_t9ksched.yaml
+++ b/job/mpijob/horovod-torch/job_gpu_t9ksched.yaml
@@ -30,7 +30,7 @@ spec:
       spec:
         containers:
           - name: mpi-worker
-            image: registry.tensorstack.cn/t9k/horovod:sdk-0.5.2
+            image: t9kpublic/horovod:sdk-0.5.2
             workingDir: /t9k/mnt/tutorial-examples
             resources:
               requests:

--- a/job/pytorchtrainingjob/ddp/job.yaml
+++ b/job/pytorchtrainingjob/ddp/job.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/pytorchtrainingjob/ddp/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -26,7 +26,7 @@ spec:
                 - "gloo"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 8
@@ -59,7 +59,7 @@ spec:
                 - "gloo"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 8

--- a/job/pytorchtrainingjob/ddp/job_gpu.yaml
+++ b/job/pytorchtrainingjob/ddp/job_gpu.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/pytorchtrainingjob/ddp/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -25,7 +25,7 @@ spec:
                 - "--backend"
                 - "nccl"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 1
@@ -59,7 +59,7 @@ spec:
                 - "--backend"
                 - "nccl"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 1

--- a/job/pytorchtrainingjob/ddp/job_gpu_t9ksched.yaml
+++ b/job/pytorchtrainingjob/ddp/job_gpu_t9ksched.yaml
@@ -10,7 +10,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/pytorchtrainingjob/ddp/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -29,7 +29,7 @@ spec:
                 - "--backend"
                 - "nccl"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 1
@@ -63,7 +63,7 @@ spec:
                 - "--backend"
                 - "nccl"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               resources:
                 requests:
                   cpu: 1

--- a/job/pytorchtrainingjob/ps/job.yaml
+++ b/job/pytorchtrainingjob/ps/job.yaml
@@ -9,7 +9,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/pytorchtrainingjob/ps/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -24,7 +24,7 @@ spec:
                 - job/pytorchtrainingjob/ps/torch_mnist_trainingjob_ps.py
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               name: pytorch
               resources:
                 requests:
@@ -57,7 +57,7 @@ spec:
                 - "job/pytorchtrainingjob/ps/model_state_dict.pt"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               name: pytorch
               resources:
                 requests:

--- a/job/pytorchtrainingjob/ps/job_gpu.yaml
+++ b/job/pytorchtrainingjob/ps/job_gpu.yaml
@@ -9,7 +9,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/pytorchtrainingjob/ps/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -23,7 +23,7 @@ spec:
                 - python
                 - job/pytorchtrainingjob/ps/torch_mnist_trainingjob_ps.py
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               name: pytorch
               resources:
                 requests:
@@ -57,7 +57,7 @@ spec:
                 - "--save_path"
                 - "job/pytorchtrainingjob/ps/model_state_dict.pt"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               name: pytorch
               resources:
                 requests:

--- a/job/pytorchtrainingjob/ps/job_gpu_t9ksched.yaml
+++ b/job/pytorchtrainingjob/ps/job_gpu_t9ksched.yaml
@@ -10,7 +10,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/pytorchtrainingjob/ps/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: master
       replicas: 1
@@ -24,7 +24,7 @@ spec:
                 - python
                 - job/pytorchtrainingjob/ps/torch_mnist_trainingjob_ps.py
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               name: pytorch
               resources:
                 requests:
@@ -58,7 +58,7 @@ spec:
                 - "--save_path"
                 - "job/pytorchtrainingjob/ps/model_state_dict.pt"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/pytorch-1.13.0:sdk-0.5.2
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
               name: pytorch
               resources:
                 requests:

--- a/job/tensorflowtrainingjob/multiworker/job.yaml
+++ b/job/tensorflowtrainingjob/multiworker/job.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/tensorflowtrainingjob/multiworker/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: worker
       replicas: 4
@@ -24,7 +24,7 @@ spec:
                 - "job/tensorflowtrainingjob/multiworker/log"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               resources:
                 requests:
                   cpu: 2

--- a/job/tensorflowtrainingjob/multiworker/job_gpu.yaml
+++ b/job/tensorflowtrainingjob/multiworker/job_gpu.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/tensorflowtrainingjob/multiworker/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: worker
       replicas: 4
@@ -23,7 +23,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/multiworker/log"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
               resources:
                 requests:
                   cpu: 1

--- a/job/tensorflowtrainingjob/multiworker/job_gpu_t9ksched.yaml
+++ b/job/tensorflowtrainingjob/multiworker/job_gpu_t9ksched.yaml
@@ -10,7 +10,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/tensorflowtrainingjob/multiworker/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: worker
       replicas: 4
@@ -27,7 +27,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/multiworker/log"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
               resources:
                 requests:
                   cpu: 1

--- a/job/tensorflowtrainingjob/ps/job.yaml
+++ b/job/tensorflowtrainingjob/ps/job.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/tensorflowtrainingjob/ps/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: chief
       replicas: 1
@@ -23,7 +23,7 @@ spec:
                 - "job/tensorflowtrainingjob/ps/log"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:
@@ -54,7 +54,7 @@ spec:
                 - "job/tensorflowtrainingjob/ps/log"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples  
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:
@@ -85,7 +85,7 @@ spec:
                 - "job/tensorflowtrainingjob/ps/log"
                 - "--no_cuda"
               workingDir: /t9k/mnt/tutorial-examples  
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:

--- a/job/tensorflowtrainingjob/ps/job_gpu.yaml
+++ b/job/tensorflowtrainingjob/ps/job_gpu.yaml
@@ -6,7 +6,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/tensorflowtrainingjob/ps/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: chief
       replicas: 1
@@ -22,7 +22,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/ps/log"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:
@@ -52,7 +52,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/ps/log"
               workingDir: /t9k/mnt/tutorial-examples  
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:
@@ -82,7 +82,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/ps/log"
               workingDir: /t9k/mnt/tutorial-examples  
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:

--- a/job/tensorflowtrainingjob/ps/job_gpu_t9ksched.yaml
+++ b/job/tensorflowtrainingjob/ps/job_gpu_t9ksched.yaml
@@ -10,7 +10,7 @@ spec:
   tensorboardSpec:
     trainingLogFilesets:
       - t9k://pvc/tutorial/tutorial-examples/job/tensorflowtrainingjob/ps/log
-    image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+    image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
   replicaSpecs:
     - type: chief
       replicas: 1
@@ -26,7 +26,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/ps/log"
               workingDir: /t9k/mnt/tutorial-examples
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:
@@ -56,7 +56,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/ps/log"
               workingDir: /t9k/mnt/tutorial-examples  
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:cpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:cpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:
@@ -86,7 +86,7 @@ spec:
                 - "--log_dir"
                 - "job/tensorflowtrainingjob/ps/log"
               workingDir: /t9k/mnt/tutorial-examples  
-              image: registry.tensorstack.cn/t9k/tensorflow-2.11.0:gpu-sdk-0.5.2
+              image: t9kpublic/tensorflow-2.11.0:gpu-sdk-0.5.2
               name: tensorflow
               resources:
                 requests:

--- a/workflow/automatic-workflow/workflowtemplates/100-tfdv.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/100-tfdv.yaml
@@ -18,7 +18,7 @@ spec:
       default: data
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: SeqPod
   seqPod:
     steps:

--- a/workflow/automatic-workflow/workflowtemplates/110-tft.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/110-tft.yaml
@@ -21,7 +21,7 @@ spec:
       default: data
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: SeqPod
   seqPod:
     steps:

--- a/workflow/automatic-workflow/workflowtemplates/200-training.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/200-training.yaml
@@ -18,7 +18,7 @@ spec:
       default: data
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: SeqPod
   seqPod:
     steps:

--- a/workflow/automatic-workflow/workflowtemplates/210-tfma.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/210-tfma.yaml
@@ -18,7 +18,7 @@ spec:
       default: data
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: SeqPod
   seqPod:
     steps:

--- a/workflow/automatic-workflow/workflowtemplates/220-confusion-matrix.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/220-confusion-matrix.yaml
@@ -15,7 +15,7 @@ spec:
       default: output
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: SeqPod
   seqPod:
     steps:

--- a/workflow/automatic-workflow/workflowtemplates/220-roc.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/220-roc.yaml
@@ -15,7 +15,7 @@ spec:
       default: output
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: SeqPod
   seqPod:
     steps:

--- a/workflow/automatic-workflow/workflowtemplates/999-taxi-tips-prediction.yaml
+++ b/workflow/automatic-workflow/workflowtemplates/999-taxi-tips-prediction.yaml
@@ -17,7 +17,7 @@ spec:
       default: data
     - name: RUNTIME_IMAGE
       description: The docker image for runnning this task.
-      default: "registry.tensorstack.cn/t9k/tfx:prod-2.1.1"
+      default: "t9kpublic/tfx:prod-2.1.1"
   type: DAG
   dag:
     templates:


### PR DESCRIPTION
弃用 `registry.tensorstack.cn`，相应的镜像都已上传到 https://hub.docker.com/repositories/t9kpublic