### PR TITLE
Another way to train with torchrun

### DIFF
--- a/job/pytorchtrainingjob/ddp/job_torchrun.yaml
+++ b/job/pytorchtrainingjob/ddp/job_torchrun.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch.tensorstack.dev/v1beta1
+kind: PyTorchTrainingJob
+metadata:
+  name: torchrun-mnist
+spec:
+  replicaSpecs:
+    - type: node
+      replicas: 2
+      restartPolicy: OnFailure
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+          containers:
+            - name: pytorch
+              command:
+                - torchrun 
+                - --nnodes 
+                - '2' 
+                - --nproc_per_node 
+                - '2' 
+                - --rdzv_backend 
+                - c10d
+                - --rdzv_endpoint 
+                - $(MASTER_ADDR):$(MASTER_PORT)
+                - --max_restarts 
+                - '3' 
+                - --role 
+                - node
+                - job/pytorchtrainingjob/ddp/torch_mnist_trainingjob.py
+                - "--log_dir"
+                - "job/pytorchtrainingjob/ddp/log"
+                - "--backend"
+                - "gloo"
+                - "--no_cuda"
+              workingDir: /t9k/mnt/tutorial-examples
+              image: t9kpublic/pytorch-1.13.0:sdk-0.5.2
+              resources:
+                requests:
+                  cpu: 8
+                  memory: 4Gi
+                limits:
+                  cpu: 16
+                  memory: 8Gi
+              volumeMounts:
+                - mountPath: /t9k/mnt
+                  name: data
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: tutorial


### PR DESCRIPTION
客户有这样的需求：

1. 已经学会用 torchrun 了，希望能在 yaml 中直观的使用 torchrun 启动
2. 希望在使用 torchrun 启动前，可以用 `conda activate $env` 设置环境，而之前使用 torchrunConfig 配置启动训练无法实现该需求

提供一个示例，可以不填写 torchrunConfig 就能用 torchrun 启动训练，如果希望用 `conda activate /t9k/mnt/env` 命令，只需要将 command 字段设置为 `sh -c "conda activate /t9k/mnt/env && torchrun --nnodes 2 --nproc_per_node 2 xxxx"`