### PR TITLE
update deployment/mlservice/torch-pvc/mlservice.yaml: add memory limit

### DIFF
--- a/deployment/mlservice/torch-pvc/mlservice.yaml
+++ b/deployment/mlservice/torch-pvc/mlservice.yaml
@@ -21,4 +21,4 @@ spec:
           resources:
             limits:
               cpu: "500m"
-              memory: 1Gi
+              memory: 2Gi


### PR DESCRIPTION
在测试时遇到了 OOMKilled 的问题。

运行环境（nuc 集群）：
* K8s v1.28.6
* 容器运行时 containerd 2.0.0-rc.1
* istio v1.20.6
* Knative v1.13.1
* T9k MLService v1.79.2

mlservice 的状态：
```bash
$k get mlservice
NAME              READY   REASON   URL                                                AGE
torch-mnist-pvc   True             http://torch-mnist-pvc.demo.ksvc.nuc.t9kcloud.cn   11m
```

Pod 的状态：
```bash
$k get pod
NAME                                                              READY   STATUS    RESTARTS      AGE
managed-notebook-d94af-0                                          2/2     Running   0             27h
managed-project-event-ctl-694df6d44f-bgnwr                        1/1     Running   0             3h10m
torch-mnist-pvc-predict-origin-00001-deployment-5f876859dfjtssd   2/2     Running   2 (26s ago)   78s
```

发送预测请求：
```bash
$address=$(kubectl get -f mlservice.yaml -ojsonpath='{.status.address.url}')
$curl -T test_data/0.png ${address}/v1/models/mnist:predict
read tcp 127.0.0.1:57054->127.0.0.1:8080: read: connection reset by peer
```

此时再查看 Pod 状态：
```bash
$k get pod -w
NAME                                                              READY   STATUS      RESTARTS      AGE
managed-notebook-d94af-0                                          2/2     Running     0             27h
managed-project-event-ctl-694df6d44f-bgnwr                        1/1     Running     0             3h10m
torch-mnist-pvc-predict-origin-00001-deployment-5f876859dfjtssd   1/2     OOMKilled   2 (44s ago)   96s
```